### PR TITLE
Remove unnecessary attributes

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -32,9 +32,7 @@ export function onRouteUpdate(
       detailed: detailed,
     }
   );
-  // Create attributes
-  const attributes = ackeeTracker.attributes();
 
   // record attributes
-  instance.record(attributes);
+  instance.record();
 }


### PR DESCRIPTION
Ackee will automatically call `ackeeTracker.attributes()` when you don't provide custom attributes. This way it will also use the `detailed` option which otherwise would have been overwritten by the custom attributes.