### PR TITLE
Update ackee-tracker to 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ plugins: [
       server: 'https://analytics.test.com',
       // Disabled analytic tracking when running localy
       ignoreLocalhost: true,
+      // Enable or disable the tracking of your own visits (as identified by your login to the Ackee dashboard).
+      ignoreOwnVisits: false,
       // If enabled it will collect info on OS, BrowserInfo, Device  & ScreenSize
       detailed: false,
     },

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -14,7 +14,7 @@ let trackerInstance;
  */
 exports.onRouteUpdate = (
   _,
-  { domainId, server, ignoreLocalhost, detailed }
+  { domainId, server, ignoreLocalhost, ignoreOwnVisits, detailed }
 ) => {
   /**
    * If there is no tracker instance, instantiate one with the plugin options.
@@ -27,6 +27,7 @@ exports.onRouteUpdate = (
       },
       {
         ignoreLocalhost,
+        ignoreOwnVisits,
         detailed,
       }
     );

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint . --ext .js --cache"
   },
   "dependencies": {
-    "ackee-tracker": "4.0.1"
+    "ackee-tracker": "^4.2"
   },
   "devDependencies": {
     "eslint": "7.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-ackee-tracker@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/ackee-tracker/-/ackee-tracker-4.0.1.tgz#174b243a5beb9878e3eea50243a133364fa7ef3e"
-  integrity sha512-gchmU9F0Sd88FsFz89/4rfj484yYKQc+eXuyPEnZhgx2sqo7X0kMsFBMO69jTg3J+hB3bU6KQjE1dP4sp7CBQQ==
+ackee-tracker@^4.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/ackee-tracker/-/ackee-tracker-4.2.0.tgz#6bae008eabdaac358c3da79b568e5e2694bed765"
+  integrity sha512-SEEr7c+6l1+leLmjf61Abkjux+NnFQON3dpoXgbnmYj/MdYcOF2qiaT8Y8jpMspNJ94CN1TKTD9uLcGrmPvBHA==
   dependencies:
     platform "^1.3.6"
 


### PR DESCRIPTION
Update ackee-tracker version to 4.2. It allows to ignore own visits using ignoreOwnVisits config.